### PR TITLE
DBZ-445 Make postGIS support optional.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,13 @@ EXTENSION = decoderbufs
 PROTOBUF_C_CFLAGS = $(shell pkg-config --cflags 'libprotobuf-c >= 1.0.0')
 PROTOBUF_C_LDFLAGS = $(shell pkg-config --libs 'libprotobuf-c >= 1.0.0')
 
-PG_CPPFLAGS += -std=c11 $(PROTOBUF_C_CFLAGS) -I/usr/local/include
-SHLIB_LINK  += $(PROTOBUF_C_LDFLAGS) -L/usr/local/lib -llwgeom
+ifneq ($(USE_POSTGIS),false)
+C_PARAMS = -DUSE_POSTGIS
+POSTGIS_C_LDFLAGS = -L/usr/local/lib -llwgeom
+endif
+
+PG_CPPFLAGS += -std=c11 $(PROTOBUF_C_CFLAGS) -I/usr/local/include $(C_PARAMS)
+SHLIB_LINK  += $(PROTOBUF_C_LDFLAGS) $(POSTGIS_C_LDFLAGS)
 
 OBJS = src/decoderbufs.o src/proto/pg_logicaldec.pb-c.o
 


### PR DESCRIPTION
Given that postGIS is an optional extension, it may be absent in some postgres installations. Having postGIS dependency mandatory seems strange, as it requires pretty enough transitive dependencies (something across 200MB).

This pull request adds ability to exclude postGIS support during build for systems without postGIS:

`make` still builds decoderbufs as before;
`make USE_POSTGIS=false` builds decoderbufs without postGIS support.