### PR TITLE
Allow a custom pg_config to be specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ SHLIB_LINK  += $(PROTOBUF_C_LDFLAGS) $(POSTGIS_C_LDFLAGS)
 
 OBJS = src/decoderbufs.o src/proto/pg_logicaldec.pb-c.o
 
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
This is what pg_repack does to allow the user to specify which version of `pg_config` it should use.

Example: https://github.com/reorg/pg_repack/blob/master/Makefile#L9

When upgrading postgres versions, it would be nice to automatically build decoderbufs for each db version to avoid accidental breakage. Better safe than sorry.

PS: I'm not sure if you guys would rather me try to get this merged upstream first or not. Just let me know and I'll move this if need be. Thanks!