### PR TITLE
Added explicit null value information

### DIFF
--- a/proto/pg_logicaldec.proto
+++ b/proto/pg_logicaldec.proto
@@ -28,6 +28,7 @@ message DatumMessage {
       bytes datum_bytes = 9;
       Point datum_point = 10;
     }
+    optional bool column_null = 11;
 }
 
 message TypeInfo {

--- a/src/decoderbufs.c
+++ b/src/decoderbufs.c
@@ -456,6 +456,7 @@ static void tuple_to_tuple_msg(Decoderbufs__DatumMessage **tmsg,
       }
     } else {
       elog(DEBUG1, "column %s is null, ignoring value", attrName);  
+      datum_msg.has_column_null = datum_msg.column_null = true;
     }
 
     tmsg[valid_attr_cnt] = palloc(sizeof(datum_msg));

--- a/src/proto/pg_logicaldec.pb-c.c
+++ b/src/proto/pg_logicaldec.pb-c.c
@@ -230,7 +230,7 @@ const ProtobufCMessageDescriptor decoderbufs__point__descriptor =
   (ProtobufCMessageInit) decoderbufs__point__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor decoderbufs__datum_message__field_descriptors[10] =
+static const ProtobufCFieldDescriptor decoderbufs__datum_message__field_descriptors[11] =
 {
   {
     "column_name",
@@ -352,9 +352,22 @@ static const ProtobufCFieldDescriptor decoderbufs__datum_message__field_descript
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "column_null",
+    11,
+    PROTOBUF_C_LABEL_OPTIONAL,
+    PROTOBUF_C_TYPE_BOOL,
+    offsetof(Decoderbufs__DatumMessage, has_column_null),
+    offsetof(Decoderbufs__DatumMessage, column_null),
+    NULL,
+    NULL,
+    0,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned decoderbufs__datum_message__field_indices_by_name[] = {
   0,   /* field[0] = column_name */
+  10,   /* field[10] = column_null */
   1,   /* field[1] = column_type */
   6,   /* field[6] = datum_bool */
   8,   /* field[8] = datum_bytes */
@@ -368,7 +381,7 @@ static const unsigned decoderbufs__datum_message__field_indices_by_name[] = {
 static const ProtobufCIntRange decoderbufs__datum_message__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 10 }
+  { 0, 11 }
 };
 const ProtobufCMessageDescriptor decoderbufs__datum_message__descriptor =
 {
@@ -378,7 +391,7 @@ const ProtobufCMessageDescriptor decoderbufs__datum_message__descriptor =
   "Decoderbufs__DatumMessage",
   "decoderbufs",
   sizeof(Decoderbufs__DatumMessage),
-  10,
+  11,
   decoderbufs__datum_message__field_descriptors,
   decoderbufs__datum_message__field_indices_by_name,
   1,  decoderbufs__datum_message__number_ranges,

--- a/src/proto/pg_logicaldec.pb-c.h
+++ b/src/proto/pg_logicaldec.pb-c.h
@@ -61,6 +61,8 @@ struct  _Decoderbufs__DatumMessage
   char *column_name;
   protobuf_c_boolean has_column_type;
   int64_t column_type;
+  protobuf_c_boolean has_column_null;
+  protobuf_c_boolean column_null;
   Decoderbufs__DatumMessage__DatumCase datum_case;
   union {
     int32_t datum_int32;
@@ -75,7 +77,7 @@ struct  _Decoderbufs__DatumMessage
 };
 #define DECODERBUFS__DATUM_MESSAGE__INIT \
  { PROTOBUF_C_MESSAGE_INIT (&decoderbufs__datum_message__descriptor) \
-    , NULL, 0,0, DECODERBUFS__DATUM_MESSAGE__DATUM__NOT_SET, {0} }
+    , NULL, 0,0, 0,0, DECODERBUFS__DATUM_MESSAGE__DATUM__NOT_SET, {0} }
 
 
 struct  _Decoderbufs__TypeInfo


### PR DESCRIPTION
When updating a row with a large text column, but the large column's value is unchanged, decoderbufs won't send the value of the column to the logical subscriber. However, the subscriber has no way to detect whether the column was left untouched or deliberately given a null value. Adding explicit null value information on each datum should rectify this situation.