### PR TITLE
Add PGXS "make installcheck" support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 MODULE_big = decoderbufs
 EXTENSION = decoderbufs
+REGRESS = decoderbufs
 
 PROTOBUF_C_CFLAGS = $(shell pkg-config --cflags 'libprotobuf-c >= 1.0.0')
 PROTOBUF_C_LDFLAGS = $(shell pkg-config --libs 'libprotobuf-c >= 1.0.0')

--- a/expected/decoderbufs.out
+++ b/expected/decoderbufs.out
@@ -1,0 +1,27 @@
+select slot_name from pg_create_logical_replication_slot('decoderbufs_demo', 'decoderbufs');
+INFO:  Exiting startup callback
+    slot_name     
+------------------
+ decoderbufs_demo
+(1 row)
+
+create table foo (id int primary key, data text);
+insert into foo values (1, 'Important stuff');
+select regexp_replace(data, '(txid|commit_time)\[\d+\]', '\1[***]', 'g') as data
+from pg_logical_slot_peek_changes('decoderbufs_demo', NULL, NULL, 'debug-mode', '1');
+NOTICE:  Decoderbufs DEBUG MODE is ON.
+INFO:  Exiting startup callback
+                            data                            
+------------------------------------------------------------
+ txid[***], commit_time[***], op[3]
+ txid[***], commit_time[***], op[4]
+ txid[***], commit_time[***], op[3]
+ txid[***], commit_time[***], table[public.foo], op[0]     +
+ NEW TUPLE:                                                +
+ column_name[id], column_type[23], datum[1]                +
+ column_name[data], column_type[25], datum[Important stuff]+
+                                                           +
+ 
+ txid[***], commit_time[***], op[4]
+(5 rows)
+

--- a/sql/decoderbufs.sql
+++ b/sql/decoderbufs.sql
@@ -1,0 +1,7 @@
+select slot_name from pg_create_logical_replication_slot('decoderbufs_demo', 'decoderbufs');
+
+create table foo (id int primary key, data text);
+insert into foo values (1, 'Important stuff');
+
+select regexp_replace(data, '(txid|commit_time)\[\d+\]', '\1[***]', 'g') as data
+from pg_logical_slot_peek_changes('decoderbufs_demo', NULL, NULL, 'debug-mode', '1');


### PR DESCRIPTION
This enables running PG's standard testsuite with a PG server configured
for decoderbufs.

Example on Debian:

```
$ sudo apt install postgresql-14-decoderbufs
$ pg_virtualenv -o shared_preload_libraries=decoderbufs -o wal_level=logical
Creating new PostgreSQL cluster 14/regress ...
$ make installcheck
/usr/lib/postgresql/14/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/usr/lib/postgresql/14/bin'    --dbname=contrib_regression decoderbufs
(using postmaster on localhost, port 5433)
============== dropping database "contrib_regression" ==============
HINWEIS:  Datenbank »contrib_regression« existiert nicht, wird übersprungen
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test decoderbufs                  ... ok           30 ms

=====================
 All 1 tests passed.
=====================

$ exit
Dropping cluster 14/regress ...
```

Tested on apt.postgresql.org with PG 10+ on amd64/arm64/i386/ppc64el.

https://pgdgbuild.dus.dg-i.net/view/Testsuite/job/postgres-decoderbufs-autopkgtest/